### PR TITLE
Add subcommands for oauth2 application templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ generate-mocks: build-testaid
 	$(GO) get github.com/vektra/mockery/.../
 	$(GOPATH)/bin/mockery -dir=core -name=DirectoryService
 	$(GOPATH)/bin/mockery -dir=core -name=ApplicationService
+	$(GOPATH)/bin/mockery -dir=core -name=AppTemplateService
 
 test: update-build-dependencies generate-mocks
 	@echo testing...

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -22,11 +22,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
 	. "github.com/vmware/priam/core"
 	"github.com/vmware/priam/mocks"
 	. "github.com/vmware/priam/testaid"
 	. "github.com/vmware/priam/util"
+	"io/ioutil"
 	"testing"
 )
 
@@ -750,4 +750,58 @@ func TestGetEntitlementWithNoNameShowsError(t *testing.T) {
 func TestGetEntitlementWithWrongTypeShowsError(t *testing.T) {
 	ctx := runner(newTstCtx(t, " "), "entitlement", "get", "actor", "swayze")
 	ctx.assertInfoErrContains("USAGE", "First parameter of 'get' must be user, group or app")
+}
+
+// - Oauth2 Application Templates
+
+// Helper to setup mock for the app template service
+func setupTemplateServiceMock() *mocks.AppTemplateService {
+	templServiceMock := new(mocks.AppTemplateService)
+	templateService = templServiceMock
+	return templServiceMock
+}
+
+func TestCanGetTemplate(t *testing.T) {
+	templServiceMock := setupTemplateServiceMock()
+	templServiceMock.On("Get", mock.Anything, "makesnow").Return()
+	testCliCommand(t, "template", "get", "makesnow")
+	templServiceMock.AssertExpectations(t)
+}
+
+// Helper to create template map
+func templateInfo(name, scope string, accessTokenTTL int) map[string]interface{} {
+	return map[string]interface{}{"scope": scope, "accessTokenTTL": accessTokenTTL,
+		"authGrantTypes": "authorization_code", "displayUserGrant": false,
+		"resourceUuid": "00000000-0000-0000-0000-000000000000", "tokenType": "Bearer",
+		"appProductId": name, "redirectUri": "horizonapi://oauth2",
+		"refreshTokenTTL": 2628000, "length": 32}
+
+}
+
+func TestCanAddTemplateWithDefaults(t *testing.T) {
+	templServiceMock := setupTemplateServiceMock()
+	templServiceMock.On("Add", mock.Anything, "olaf", templateInfo("olaf", "user profile email", 480)).Return()
+	testCliCommand(t, "template", "add", "olaf")
+	templServiceMock.AssertExpectations(t)
+}
+
+func TestCanAddTemplateWithOptions(t *testing.T) {
+	templServiceMock := setupTemplateServiceMock()
+	templServiceMock.On("Add", mock.Anything, "olaf", templateInfo("olaf", "snow", 0)).Return()
+	testCliCommand(t, "template", "add", "--scope", "snow", "--accessTokenTTL", "0", "olaf")
+	templServiceMock.AssertExpectations(t)
+}
+
+func TestCanDeleteTemplate(t *testing.T) {
+	templServiceMock := setupTemplateServiceMock()
+	templServiceMock.On("Delete", mock.Anything, "sven").Return()
+	testCliCommand(t, "template", "delete", "sven")
+	templServiceMock.AssertExpectations(t)
+}
+
+func TestCanListTemplates(t *testing.T) {
+	templServiceMock := setupTemplateServiceMock()
+	templServiceMock.On("List", mock.Anything).Return()
+	testCliCommand(t, "template", "list")
+	templServiceMock.AssertExpectations(t)
 }

--- a/core/misc_test.go
+++ b/core/misc_test.go
@@ -17,9 +17,9 @@ package core
 
 import (
 	"github.com/stretchr/testify/assert"
-	"net/http/httptest"
 	. "github.com/vmware/priam/testaid"
 	. "github.com/vmware/priam/util"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -47,6 +47,12 @@ func NewTestContext(t *testing.T, paths map[string]TstHandler) (*httptest.Server
 func AssertOnlyInfoContains(t *testing.T, ctx *HttpContext, expected string) {
 	assert.Empty(t, ctx.Log.ErrString(), "Error message should be empty")
 	assert.Contains(t, ctx.Log.InfoString(), expected, "INFO log message should contain '"+expected+"'")
+}
+
+// Assert context error contains the given string, and info is empty
+func AssertOnlyErrorContains(t *testing.T, ctx *HttpContext, expected string) {
+	assert.Empty(t, ctx.Log.InfoString(), "Info message should be empty")
+	assert.Contains(t, ctx.Log.ErrString(), expected, "ERROR log message should contain '"+expected+"'")
 }
 
 // Assert context error contains the given string

--- a/core/templates.go
+++ b/core/templates.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	. "github.com/vmware/priam/util"
+)
+
+// The application service interface.
+type AppTemplateService interface {
+	// Add creates a new app template
+	Add(ctx *HttpContext, name string, templateInfo map[string]interface{})
+
+	// Get displays the given application template by name
+	Get(ctx *HttpContext, name string)
+
+	// Delete deletes the given application template by name
+	Delete(ctx *HttpContext, name string)
+
+	// List displays all application templates
+	List(ctx *HttpContext)
+}
+
+// the IDM application template service
+type IDMAppTemplateService struct{}
+
+const templatePath = "oauth2apptemplates"
+
+var templateSummaryFields = []string{"items", "appProductId", "accessTokenTTL", "authGrantTypes",
+	"redirectUri", "displayUserGrant", "length", "refreshTokenTTL", "resourceUuid", "scope", "tokenType"}
+
+// Get oauth2 application template info
+func (service IDMAppTemplateService) Get(ctx *HttpContext, name string) {
+	ctx.GetPrintJson("Get App Template "+name, templatePath+"/"+name, "oauth2apptemplate", templateSummaryFields...)
+}
+
+// Delete oauth2 application template
+func (service IDMAppTemplateService) Delete(ctx *HttpContext, name string) {
+	if err := ctx.Request("DELETE", templatePath+"/"+name, nil, nil); err != nil {
+		ctx.Log.Err("Error deleting template \"%s\": %v\n", name, err)
+	} else {
+		ctx.Log.Info("Template \"%s\" deleted\n", name)
+	}
+}
+
+// List all oauth2 application templates
+func (service IDMAppTemplateService) List(ctx *HttpContext) {
+	ctx.GetPrintJson("List App Templates", templatePath, "oauth2apptemplate.list", templateSummaryFields...)
+}
+
+// add a new oauth2 application template
+func (service IDMAppTemplateService) Add(ctx *HttpContext, name string, templateInfo map[string]interface{}) {
+	if err := ctx.ContentType("oauth2apptemplate").Request("POST", templatePath, templateInfo, nil); err != nil {
+		ctx.Log.Err("Error adding template \"%s\": %v\n", name, err)
+	} else {
+		ctx.Log.Info("Successfully added template \"%s\"\n", name)
+	}
+}

--- a/core/templates_test.go
+++ b/core/templates_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"github.com/stretchr/testify/assert"
+	. "github.com/vmware/priam/testaid"
+	"testing"
+)
+
+const appTemplateMT = "oauth2apptemplate+json"
+const appTemplateListMT = "oauth2apptemplate.list+json"
+const appTemplateItem = `{"appProductId": "olaf", "resourceUuid": "6c48beb6-afb1-44bc-ad7f-980214ee346c"}`
+const appTemplateList = `{"items": [` + appTemplateItem + `]}`
+const appTemplateBasePath = "/oauth2apptemplates"
+
+func TestAppTemplateGet(t *testing.T) {
+	srv, ctx := NewTestContext(t, map[string]TstHandler{
+		"GET" + appTemplateBasePath + "/olaf": func(t *testing.T, req *TstReq) *TstReply {
+			assert.Equal(t, appTemplateMT, req.Accept)
+			return &TstReply{Status: 200, Output: appTemplateItem, ContentType: appTemplateMT}
+		}})
+	defer srv.Close()
+	new(IDMAppTemplateService).Get(ctx, "olaf")
+	AssertOnlyInfoContains(t, ctx, `appProductId: olaf`)
+}
+
+func TestAppTemplateNotFound(t *testing.T) {
+	srv, ctx := NewTestContext(t, map[string]TstHandler{
+		"GET" + appTemplateBasePath + "/hans": func(t *testing.T, req *TstReq) *TstReply {
+			assert.Equal(t, appTemplateMT, req.Accept)
+			return &TstReply{Status: 404, Output: `{"message":"oauth2apptemplate.not.found"}`,
+				ContentType: "application/json"}
+		}})
+	defer srv.Close()
+	new(IDMAppTemplateService).Get(ctx, "hans")
+	AssertOnlyErrorContains(t, ctx, `Error: 404 Not Found`)
+	AssertOnlyErrorContains(t, ctx, `oauth2apptemplate.not.found`)
+}
+
+func TestAppTemplateList(t *testing.T) {
+	srv, ctx := NewTestContext(t, map[string]TstHandler{
+		"GET" + appTemplateBasePath: func(t *testing.T, req *TstReq) *TstReply {
+			assert.Equal(t, appTemplateListMT, req.Accept)
+			return &TstReply{Status: 200, Output: appTemplateList, ContentType: appTemplateListMT}
+		}})
+	defer srv.Close()
+	new(IDMAppTemplateService).List(ctx)
+	AssertOnlyInfoContains(t, ctx, `items`)
+	AssertOnlyInfoContains(t, ctx, `appProductId: olaf`)
+}
+
+func TestAppTemplateListRejected(t *testing.T) {
+	srv, ctx := NewTestContext(t, map[string]TstHandler{
+		"GET" + appTemplateBasePath: func(t *testing.T, req *TstReq) *TstReply {
+			assert.Equal(t, appTemplateListMT, req.Accept)
+			return &TstReply{Status: 403}
+		}})
+	defer srv.Close()
+	new(IDMAppTemplateService).List(ctx)
+	AssertOnlyErrorContains(t, ctx, `Error: 403 Forbidden`)
+}
+
+func TestAppTemplateDelete(t *testing.T) {
+	srv, ctx := NewTestContext(t, map[string]TstHandler{
+		"DELETE" + appTemplateBasePath + "/olaf": func(t *testing.T, req *TstReq) *TstReply {
+			return &TstReply{Status: 200}
+		}})
+	defer srv.Close()
+	new(IDMAppTemplateService).Delete(ctx, "olaf")
+	AssertOnlyInfoContains(t, ctx, `Template "olaf" deleted`)
+}
+
+func TestAppTemplateDeleteRejected(t *testing.T) {
+	srv, ctx := NewTestContext(t, map[string]TstHandler{
+		"DELETE" + appTemplateBasePath + "/olaf": func(t *testing.T, req *TstReq) *TstReply {
+			return &TstReply{Status: 500, Output: "elsa's in a bad mood"}
+		}})
+	defer srv.Close()
+	new(IDMAppTemplateService).Delete(ctx, "olaf")
+	AssertOnlyErrorContains(t, ctx, `Error deleting template "olaf": 500 Internal Server Error`)
+}
+
+func TestAppTemplateAdd(t *testing.T) {
+	srv, ctx := NewTestContext(t, map[string]TstHandler{
+		"POST" + appTemplateBasePath: func(t *testing.T, req *TstReq) *TstReply {
+			assert.Equal(t, appTemplateMT, req.ContentType)
+			assert.Equal(t, `{"appProductId":"olaf"}`, req.Input)
+			return &TstReply{Status: 200, Output: appTemplateItem, ContentType: appTemplateMT}
+		}})
+	defer srv.Close()
+	new(IDMAppTemplateService).Add(ctx, "olaf", map[string]interface{}{"appProductId": "olaf"})
+	AssertOnlyInfoContains(t, ctx, `Successfully added template "olaf"`)
+}
+
+func TestAppTemplateRejected(t *testing.T) {
+	srv, ctx := NewTestContext(t, map[string]TstHandler{
+		"POST" + appTemplateBasePath: func(t *testing.T, req *TstReq) *TstReply {
+			assert.Equal(t, appTemplateMT, req.ContentType)
+			return &TstReply{Status: 406, ContentType: "application/json",
+				Output: `{"message":"clumsy attempt at kindness is scorned by elsa"}`}
+		}})
+	defer srv.Close()
+	new(IDMAppTemplateService).Add(ctx, "sven", map[string]interface{}{"appProductId": "sven",
+		"scope": "coffee", "redirectUri": "elsa:://insecure"})
+	AssertOnlyErrorContains(t, ctx, `clumsy`)
+	AssertOnlyErrorContains(t, ctx, `406`)
+}

--- a/testaid/http.go
+++ b/testaid/http.go
@@ -57,11 +57,10 @@ func StartTstServer(t *testing.T, paths map[string]TstHandler) *httptest.Server 
 				string(rbody)})
 			if reply.Status != 0 && reply.Status != 200 {
 				http.Error(w, reply.StatusMsg, reply.Status)
-			} else {
-				w.Header().Set("Content-Type", stringOrDefault(reply.ContentType, "application/json"))
-				_, err = io.WriteString(w, reply.Output)
-				assert.Nil(t, err)
 			}
+			w.Header().Set("Content-Type", stringOrDefault(reply.ContentType, "application/json"))
+			_, err = io.WriteString(w, reply.Output)
+			assert.Nil(t, err)
 		}
 	}
 	return httptest.NewServer(http.HandlerFunc(handler))

--- a/util/http.go
+++ b/util/http.go
@@ -31,15 +31,15 @@ import (
 )
 
 type HttpContext struct {
-	Log           *Logr
-	HostURL       string
+	Log     *Logr
+	HostURL string
 
 	/* basePath is a convenience so that many callers can use a short
 	 * portion of a path from a common root. If a path for a given request
 	 * starts with '/', basePath is ignored. Otherwise it is used to prefix
 	 * the given path.
 	 */
-	basePath      string
+	basePath string
 
 	/* baseMediaType is a convenience so that many callers can use a short
 	 * portion of a set of long media type strings.
@@ -230,14 +230,14 @@ func (ctx *HttpContext) FileUploadRequest(method, path, key, mediaType string, c
 
 // sets the ctx.authHeader with basic auth
 func (ctx *HttpContext) BasicAuth(name, pwd string) *HttpContext {
-	return ctx.Authorization("Basic " + base64.StdEncoding.EncodeToString([]byte(name + ":" + pwd)))
+	return ctx.Authorization("Basic " + base64.StdEncoding.EncodeToString([]byte(name+":"+pwd)))
 }
 
-func (ctx *HttpContext) GetPrintJson(prefix, path, mediaType string) {
+func (ctx *HttpContext) GetPrintJson(prefix, path, mediaType string, filter ...string) {
 	var outp interface{}
 	if err := ctx.Accept(mediaType).Request("GET", path, nil, &outp); err != nil {
-		ctx.Log.Err("Error: %v\n", err)
+		ctx.Log.Err("%s\nError: %v\n", prefix, err)
 	} else {
-		ctx.Log.PP(prefix, outp)
+		ctx.Log.PP(prefix, outp, filter...)
 	}
 }


### PR DESCRIPTION
Added support to add, list, get, delete (oauth2 app) templates.

Testing done: manual and new unit tests.

  # make
  # make cover

Test Coverage: all new code is covered with 100% test coverage, including
some negative tests.