### PR TITLE
Login: support specifying domain

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -317,6 +317,7 @@ func Priam(args []string, defaultCfgFile string, infoW, errorW io.Writer) {
 			Description: "if password is not given as an argument, user will be prompted to enter it",
 			Flags: []cli.Flag{
 				cli.BoolFlag{Name: "client, c", Usage: "authenticate with oauth2 client ID and secret"},
+				cli.StringFlag{Name: "domain, d", Usage: "specifies the user's domain (default is 'Local Users')"},
 			},
 			Action: func(c *cli.Context) error {
 				if a, ctx := initCmd(cfg, c, 1, 2, false, nil); ctx != nil {
@@ -324,8 +325,11 @@ func Priam(args []string, defaultCfgFile string, infoW, errorW io.Writer) {
 					if c.Bool("client") {
 						prompt, path, login = "Secret", vidmTokenPath, ClientCredentialsGrant
 					}
+
+					domain := StringOrDefault(c.String("domain"), LocalUserDomain)
+					cfg.Log.Info(fmt.Sprintf("Domain: %s\n", domain))
 					pwd := getArgOrPassword(cfg.Log, prompt, a[1], false)
-					if authHeader, err := login(ctx, path, a[0], pwd); err != nil {
+					if authHeader, err := login(ctx, path, a[0], pwd, domain); err != nil {
 						cfg.Log.Err("Error getting access token: %v\n", err)
 					} else if cfg.WithAuthHeader(authHeader).Save() {
 						cfg.Log.Info("Access token saved\n")

--- a/core/login.go
+++ b/core/login.go
@@ -17,15 +17,18 @@ package core
 
 import (
 	"fmt"
-	"net/url"
 	. "github.com/vmware/priam/util"
+	"net/url"
 )
+
+/* Local user domain as defined in IDM (might change in the future when multiple local domains will be supported) . */
+const LocalUserDomain = "Local Users"
 
 /* ClientCredsGrant takes a clientID and clientSecret and makes a request for an access token.
    The access token is returned in a string prefixed by the token type for use in an http
    authorization header.
 */
-func ClientCredentialsGrant(ctx *HttpContext, path, clientID, clientSecret string) (authHeader string, err error) {
+func ClientCredentialsGrant(ctx *HttpContext, path, clientID, clientSecret string, unused string) (authHeader string, err error) {
 	tokenInfo := struct {
 		Access_token, Token_type, Refresh_token, Scope string
 		Expires_in                                     int
@@ -38,14 +41,14 @@ func ClientCredentialsGrant(ctx *HttpContext, path, clientID, clientSecret strin
 	return
 }
 
-/* LoginSystemUser takes a username and password and makes a request for an access token.
+/* LoginSystemUser takes a username, password and domain and makes a request for an access token.
    This is not an OAuth2 call but uses a vidm specific API.
    The access token is returned in a string prefixed by the token type, suitable for use
    in an http authorization header.
 */
-func LoginSystemUser(ctx *HttpContext, path, user, password string) (authHeader string, err error) {
+func LoginSystemUser(ctx *HttpContext, path, user, password string, domain string) (authHeader string, err error) {
 	tokenInfo := struct{ SessionToken string }{}
-	inp := fmt.Sprintf(`{"username": "%s", "password": "%s", "issueToken": true}`, user, password)
+	inp := fmt.Sprintf(`{"username": "%s", "password": "%s", "domain": "%s", "issueToken": true}`, user, password, domain)
 	if err = ctx.ContentType("json").Accept("json").Request("POST", path, inp, &tokenInfo); err == nil {
 		authHeader = "HZN " + tokenInfo.SessionToken
 	}


### PR DESCRIPTION
The same user can exist in different domains,
so allow the user to specify the domain when
logging in.
Default is "Local Users"

Testing Done:  $ make
+ local tests:

$ ./priam login -d foo alohauser1 'password'
Domain: foo
Error getting access token: 401
Invalid credentials.

$ ./priam login alohauser1 'password'
Domain: Local Users
Access token saved

$ ./priam login alohauser1
Domain: Local Users
Password:
Access token saved

Bug Number: 1