### PR TITLE
Make interface to config options more flexible

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -571,7 +571,7 @@ func Priam(args []string, defaultCfgFile string, infoW, errorW io.Writer) {
 					Name: "validate", Usage: "validate the current ID token (if logged in)", ArgsUsage: " ",
 					Action: func(c *cli.Context) error {
 						if _, ctx := initCmd(cfg, c, 0, 0, true, nil); ctx != nil {
-							tokenService.ValidateIDToken(ctx, cfg.IdToken())
+							tokenService.ValidateIDToken(ctx, cfg.Option(idTokenOption))
 						}
 						return nil
 					},

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -29,8 +29,12 @@ import (
 )
 
 const (
-	vidmBasePath      = "/SAAS/jersey/manager/api/"
-	vidmBaseMediaType = "application/vnd.vmware.horizon.manager."
+	vidmBasePath          = "/SAAS/jersey/manager/api/"
+	vidmBaseMediaType     = "application/vnd.vmware.horizon.manager."
+	accessTokenOption     = "accesstoken"
+	accessTokenTypeOption = "accesstokentype"
+	refreshTokenOption    = "refreshtoken"
+	idTokenOption         = "idtoken"
 )
 
 // service instances for CLI
@@ -92,11 +96,11 @@ func InitCtx(cfg *Config, authn bool) *HttpContext {
 	}
 	ctx := NewHttpContext(cfg.Log, cfg.Option(HostOption), vidmBasePath, vidmBaseMediaType)
 	if authn {
-		if token := cfg.Option("accesstoken"); token == "" {
+		if token := cfg.Option(accessTokenOption); token == "" {
 			cfg.Log.Err("No access token saved for current target. Please log in.\n")
 			return nil
 		} else {
-			ctx.Authorization(cfg.Option("accesstokentype") + " " + token)
+			ctx.Authorization(cfg.Option(accessTokenTypeOption) + " " + token)
 		}
 	}
 	return ctx
@@ -427,8 +431,9 @@ func Priam(args []string, defaultCfgFile string, infoW, errorW io.Writer) {
 							return nil
 						}
 					}
-					opts := map[string]string{"accesstokentype": tokenInfo.AccessTokenType, "accesstoken": tokenInfo.AccessToken,
-						"refreshtoken": tokenInfo.RefreshToken, "idtoken": tokenInfo.IDToken}
+					opts := map[string]string{accessTokenTypeOption: tokenInfo.AccessTokenType,
+						accessTokenOption: tokenInfo.AccessToken, refreshTokenOption: tokenInfo.RefreshToken,
+						idTokenOption: tokenInfo.IDToken}
 					if cfg.WithOptions(opts).Save() {
 						cfg.Log.Info("Access token saved\n")
 					}
@@ -440,7 +445,7 @@ func Priam(args []string, defaultCfgFile string, infoW, errorW io.Writer) {
 			Name: "logout", Usage: "deletes access token from configuration store for current target",
 			Action: func(c *cli.Context) error {
 				if args := initArgs(cfg, c, 0, 0, nil); args != nil &&
-					cfg.WithoutOptions("accesstokentype", "accesstoken", "refreshtoken", "idtoken").Save() {
+					cfg.WithoutOptions(accessTokenTypeOption, accessTokenOption, refreshTokenOption, idTokenOption).Save() {
 					cfg.Log.Info("Access token removed\n")
 				}
 				return nil

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -91,7 +91,8 @@ func tstSrvTgt(url string) string {
 }
 
 func tstSrvTgtWithAuth(url string) string {
-	return fmt.Sprintf("%s    accesstokentype: Bearer\n    accesstoken: %s\n    idtoken: %s\n", tstSrvTgt(url), goodAccessToken, goodIdToken)
+	return fmt.Sprintf("%s    %s: Bearer\n    %s: %s\n    %s: %s\n", tstSrvTgt(url),
+		accessTokenTypeOption, accessTokenOption, goodAccessToken, idTokenOption, goodIdToken)
 }
 
 func runner(ctx *tstCtx, args ...string) *tstCtx {
@@ -307,8 +308,8 @@ func TestCanHandleBadOAuthClientCredentialsGrantReply(t *testing.T) {
 
 // Helper function for OAuth2 login
 func assertLoginSucceeded(t *testing.T, tokenType string, ctx *tstCtx) {
-	assert.Contains(t, ctx.cfg, "accesstokentype: "+tokenType)
-	assert.Contains(t, ctx.cfg, "accesstoken: "+goodAccessToken)
+	assert.Contains(t, ctx.cfg, accessTokenTypeOption+": "+tokenType)
+	assert.Contains(t, ctx.cfg, accessTokenOption+": "+goodAccessToken)
 	ctx.assertOnlyInfoContains("Access token saved")
 }
 
@@ -425,7 +426,7 @@ func TestAuthCodeGrantWithHint(t *testing.T) {
 
 func TestLogout(t *testing.T) {
 	ctx := testCliCommand(t, "logout")
-	assert.NotContains(t, ctx.cfg, "accesstoken")
+	assert.NotContains(t, ctx.cfg, accessTokenOption)
 	assert.NotContains(t, ctx.cfg, goodAccessToken)
 	ctx.assertOnlyInfoContains("Access token removed")
 }

--- a/util/config.go
+++ b/util/config.go
@@ -130,11 +130,6 @@ func (cfg *Config) WithoutOptions(optionKeys ...string) *Config {
 	return cfg
 }
 
-/* Return the ID token, or "" if does not exist. */
-func (cfg *Config) IdToken() string {
-	return cfg.Targets[cfg.CurrentTarget].IDToken
-}
-
 func ensureFullURL(url string) string {
 	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
 		return url


### PR DESCRIPTION
Previously all target options were saved as a struct. This required
changes to the config target structure every time a new option needed
to be saved. This commit changes target options to a generic hash and
added generic interfaces to get or remove options.

Testing done:
* existing unit tests gave 100% coverage for new implementation
* manual testing
  $ ./priam login -a
check ~/.priam.yaml
  $ ./priam logout
check ~/.priam.yaml