### PR TITLE
Add register subcommand to support authcode login

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ or
 
 You need an IDM organization (like https://xxx.vmwareidentity.com)
 
-Almost all commands require the user to be logged in as an IDM admininistrator to run API calls.
+Almost all commands require the user to be logged in as an IDM administrator to run API calls.
 All examples below assume you have run the following commands before:
 
     $ priam target https://xxx.vmwareidentity.com
@@ -71,6 +71,24 @@ Note that you can also login with an OAuth 2.0 client_id and secret. In that cas
     $ priam login -c <oauth2 client id>
     Secret: <the oauth2 secret>
     Access token saved
+
+You can also login using an OAuth2 authorization code flow. This allows you to log in as any user, 
+not just a user in the system domain as shown above. It launches an external browser and opens
+a local http listener to recieve the OAuth2 tokens. However, to use this login option this 
+application must be registered as an OAuth2 client in the target tenant. A helper command is 
+provided for this purpose. If you are logged in as an administrator using one of the previous
+login options, you can run this command to register the OAuth2 client:
+
+    $ priam client register
+
+To see what options are registered (client_id, client_secret, scopes, etc), run:
+
+    $ priam client register --help
+
+After registration is completed, you can log in as a user from any domain supported by the 
+tenant, and using authentication methods as specified by access policy:
+
+    $ priam login -a
 
 ### Users
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Note that you can also login with an OAuth 2.0 client_id and secret. In that cas
 
 You can also login using an OAuth2 authorization code flow. This allows you to log in as any user, 
 not just a user in the system domain as shown above. It launches an external browser and opens
-a local http listener to recieve the OAuth2 tokens. However, to use this login option this 
+a local http listener to receive the OAuth2 tokens. However, to use this login option this 
 application must be registered as an OAuth2 client in the target tenant. A helper command is 
 provided for this purpose. If you are logged in as an administrator using one of the previous
 login options, you can run this command to register the OAuth2 client:

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -895,6 +895,12 @@ func TestCanListClients(t *testing.T) {
 	testMockCommand(t, &clntServiceMock.Mock, "client", "list")
 }
 
+func TestCanRegisterCliClient(t *testing.T) {
+	clntServiceMock := setupClientServiceMock()
+	clntServiceMock.On("Add", mock.Anything, cliClientID, cliClientRegistration).Return()
+	testMockCommand(t, &clntServiceMock.Mock, "client", "register")
+}
+
 // Token
 
 func TestCanValidateIDToken(t *testing.T) {

--- a/core/token_test.go
+++ b/core/token_test.go
@@ -102,13 +102,13 @@ func simulateBrowser(t *testing.T, replyType codeReplyType, authcode string) fun
 		purl, err := url.Parse(authzURL)
 		assert.Nil(t, err)
 		vals := purl.Query()
-		assert.Equal(t, catcherHost+catcherPath, vals.Get("redirect_uri"))
+		assert.Equal(t, TokenCatcherURI, vals.Get("redirect_uri"))
 		assert.Equal(t, testTS.CliClientID, vals.Get("client_id"))
 		assert.Equal(t, "code", vals.Get("response_type"))
 		assert.Equal(t, "kazak", vals.Get("login_hint"))
 		state := vals.Get("state")
 		assert.NotNil(t, state)
-		hc, outp := NewHttpContext(NewBufferedLogr(), catcherHost, "", ""), ""
+		hc, outp := NewHttpContext(NewBufferedLogr(), TokenCatcherHost, "", ""), ""
 		switch replyType {
 		case goodReply:
 			vals = url.Values{"code": {authcode}, "state": {state}}
@@ -117,7 +117,7 @@ func simulateBrowser(t *testing.T, replyType codeReplyType, authcode string) fun
 		case errorReply:
 			vals = url.Values{"error": {"server_error"}, "error_description": {"so it goes..."}, "state": {state}}
 		}
-		err = hc.Request("GET", catcherPath+"?"+vals.Encode(), nil, &outp)
+		err = hc.Request("GET", TokenCatcherPath+"?"+vals.Encode(), nil, &outp)
 		assert.Nil(t, err)
 		return nil
 	}
@@ -130,7 +130,7 @@ func tokenHandler(authcode string) func(t *testing.T, req *TstReq) *TstReply {
 		vals, err := url.ParseQuery(req.Input)
 		assert.Nil(t, err)
 		assert.Equal(t, "authorization_code", vals.Get("grant_type"))
-		assert.Equal(t, catcherHost+catcherPath, vals.Get("redirect_uri"))
+		assert.Equal(t, TokenCatcherURI, vals.Get("redirect_uri"))
 		assert.Equal(t, testTS.CliClientID, vals.Get("client_id"))
 		if vals.Get("code") != authcode {
 			return &TstReply{Status: 400, Output: `{"error": "invalid_request", "error_description": "so it goes..."}`}


### PR DESCRIPTION
Added a subcommand to register the priam client in the target
tenant. Updated the readme as well.

Testing done: added unit tests. Manually tested:

   $ priam client register

   $ priam client register -h

   $ priam login -a

Manually validated tokens.