### PR TITLE
cleanup 2 command return types

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -408,12 +408,7 @@ func Priam(args []string, defaultCfgFile string, infoW, errorW io.Writer) {
 			Name: "health", Usage: "check workspace service health", ArgsUsage: " ",
 			Action: func(c *cli.Context) error {
 				if _, ctx := initCmd(cfg, c, 0, 0, false, nil); ctx != nil {
-					var outp interface{}
-					if err := ctx.Request("GET", "health", nil, &outp); err != nil {
-						ctx.Log.Err("Error on Check Health: %v\n", err)
-					} else {
-						ctx.Log.PP("Health info", outp)
-					}
+					HealthCheck(ctx)
 				}
 				return nil
 			},
@@ -611,11 +606,7 @@ func Priam(args []string, defaultCfgFile string, infoW, errorW io.Writer) {
 					Flags: userAttrFlags,
 					Action: func(c *cli.Context) error {
 						if user, ctx := initUserCmd(cfg, c, true); ctx != nil {
-							if err := usersService.AddEntity(ctx, user); err != nil {
-								ctx.Log.Err("Error creating user '%s': %v\n", user.Name, err)
-							} else {
-								ctx.Log.Info(fmt.Sprintf("User '%s' successfully added\n", user.Name))
-							}
+							usersService.AddEntity(ctx, user)
 						}
 						return nil
 					},

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -459,17 +459,8 @@ func setupUsersServiceMock() *mocks.DirectoryService {
 
 func TestCanAddUser(t *testing.T) {
 	usersServiceMock := setupUsersServiceMock()
-	usersServiceMock.On("AddEntity", mock.Anything, &BasicUser{Name: "elsa", Given: "", Family: "", Email: "", Pwd: "frozen"}).Return(nil)
-	ctx := testMockCommand(t, &usersServiceMock.Mock, "user", "add", "elsa", "frozen")
-	ctx.assertOnlyInfoContains("User 'elsa' successfully added")
-}
-
-func TestDisplayErrorWhenAddUserFails(t *testing.T) {
-	usersServiceMock := setupUsersServiceMock()
-	usersServiceMock.On("AddEntity",
-		mock.Anything, &BasicUser{Name: "elsa", Given: "", Family: "", Email: "", Pwd: "frozen"}).Return(errors.New("test"))
-	ctx := testMockCommand(t, &usersServiceMock.Mock, "user", "add", "elsa", "frozen")
-	assert.Contains(t, ctx.err, "Error creating user 'elsa': test")
+	usersServiceMock.On("AddEntity", mock.Anything, &BasicUser{Name: "elsa", Given: "", Family: "", Email: "", Pwd: "frozen"}).Return()
+	testMockCommand(t, &usersServiceMock.Mock, "user", "add", "elsa", "frozen")
 }
 
 func TestCanGetUser(t *testing.T) {

--- a/core/directoryservice.go
+++ b/core/directoryservice.go
@@ -23,7 +23,7 @@ import (
 // The directory contains different entities (User, Group, Role, ...)
 type DirectoryService interface {
 	// Add an entity
-	AddEntity(ctx *util.HttpContext, entity interface{}) error
+	AddEntity(ctx *util.HttpContext, entity interface{})
 
 	// Display an entity
 	DisplayEntity(ctx *util.HttpContext, name string)

--- a/core/misc.go
+++ b/core/misc.go
@@ -76,3 +76,12 @@ func CmdSchema(ctx *HttpContext, name string) {
 	path := fmt.Sprintf("scim/Schemas?%v", vals.Encode())
 	ctx.GetPrintJson("Schema for "+name, path, "")
 }
+
+func HealthCheck(ctx *HttpContext) {
+	var outp interface{}
+	if err := ctx.Request("GET", "health", nil, &outp); err != nil {
+		ctx.Log.Err("Error on Check Health: %v\n", err)
+	} else {
+		ctx.Log.PP("Health info", outp)
+	}
+}


### PR DESCRIPTION
Almost all commands (except those that return values to the
configuration file) return nothing to the cli layer. All output
and errors are logged to the context. This change is to fix the
only two commands, "user add" and "health" that were not consistent.

testing done: unit tests and manual

  $ ./priam add user woz

  $ ./priam health