### PR TITLE
cli client registration command ommitted openid scope

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -41,7 +41,7 @@ const (
 
 var cliClientRegistration = map[string]interface{}{"clientId": cliClientID, "secret": cliClientSecret,
 	"accessTokenTTL": 60 * 60, "authGrantTypes": "authorization_code refresh_token", "displayUserGrant": false,
-	"redirectUri": TokenCatcherURI, "refreshTokenTTL": 60 * 60 * 24 * 30, "scope": "user profile email admin"}
+	"redirectUri": TokenCatcherURI, "refreshTokenTTL": 60 * 60 * 24 * 30, "scope": "openid user profile email admin"}
 
 var registerDescription = `Registers this application as an OAuth2 client in the target tenant so that
    the login option with authorization code flow can be used. You must be logged

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -887,7 +887,7 @@ func TestCanListClients(t *testing.T) {
 }
 
 func TestCanRegisterCliClient(t *testing.T) {
-	expectedCliClientRegistration := map[string]interface{}{"clientId": cliClientID, "secret": cliClientSecret,
+	expectedCliClientRegistration := map[string]interface{}{"clientId": "github.com-vmware-priam", "secret": "not-a-secret",
 		"accessTokenTTL": 60 * 60, "authGrantTypes": "authorization_code refresh_token", "displayUserGrant": false,
 		"redirectUri": TokenCatcherURI, "refreshTokenTTL": 60 * 60 * 24 * 30, "scope": "openid user profile email admin"}
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -887,8 +887,12 @@ func TestCanListClients(t *testing.T) {
 }
 
 func TestCanRegisterCliClient(t *testing.T) {
+	expectedCliClientRegistration := map[string]interface{}{"clientId": cliClientID, "secret": cliClientSecret,
+		"accessTokenTTL": 60 * 60, "authGrantTypes": "authorization_code refresh_token", "displayUserGrant": false,
+		"redirectUri": TokenCatcherURI, "refreshTokenTTL": 60 * 60 * 24 * 30, "scope": "openid user profile email admin"}
+
 	clntServiceMock := setupClientServiceMock()
-	clntServiceMock.On("Add", mock.Anything, cliClientID, cliClientRegistration).Return()
+	clntServiceMock.On("Add", mock.Anything, cliClientID, expectedCliClientRegistration).Return()
 	testMockCommand(t, &clntServiceMock.Mock, "client", "register")
 }
 


### PR DESCRIPTION
Logging in with the "-a" authorization code flow didn't get an
ID token because the priam cli client registratin did not register
the openid scope. This change adds openid to the scopes
registered for the cli client. 

Testing Done: unit tests

  $ priam client delete github.com-vmware-priam
  $ priam client register
  $ priam client login -a
  # manually checked id token in ~/.priam.yaml