### PR TITLE
Update aws cli credentials

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -41,7 +41,7 @@ const (
 
 var cliClientRegistration = map[string]interface{}{"clientId": cliClientID, "secret": cliClientSecret,
 	"accessTokenTTL": 60 * 60, "authGrantTypes": "authorization_code refresh_token", "displayUserGrant": false,
-	"redirectUri": TokenCatcherURI, "refreshTokenTTL": 60 * 60 * 24 * 30, "scope": "user profile email admin"}
+	"redirectUri": TokenCatcherURI, "refreshTokenTTL": 60 * 60 * 24 * 30, "scope": "openid user profile email admin"}
 
 var registerDescription = `Registers this application as an OAuth2 client in the target tenant so that
    the login option with authorization code flow can be used. You must be logged

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -596,6 +596,16 @@ func Priam(args []string, defaultCfgFile string, infoW, errorW io.Writer) {
 						return nil
 					},
 				},
+				{
+					Name: "aws", Usage: "Using an ID token update AWS credentials in the AWS CLI configuration file", ArgsUsage: "[aws-config-file] ",
+					Action: func(c *cli.Context) error {
+						if args, ctx := initCmd(cfg, c, 0, 1, true, nil); ctx != nil {
+							tokenService.UpdateAWSCredentials(ctx, cfg.Option(idTokenOption),
+								StringOrDefault(args[0], filepath.Join(os.Getenv("HOME"), ".aws/credentials")))
+						}
+						return nil
+					},
+				},
 			},
 		},
 		{

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -607,7 +607,6 @@ func Priam(args []string, defaultCfgFile string, infoW, errorW io.Writer) {
 					},
 					Action: func(c *cli.Context) error {
 						if args, ctx := initCmd(cfg, c, 1, 1, false, nil); ctx != nil {
-							println("here", args[0])
 							tokenService.UpdateAWSCredentials(ctx.Log, cfg.Option(idTokenOption),
 								args[0], defaultAwsStsEndpoint,
 								StringOrDefault(c.String("credfile"), filepath.Join(os.Getenv("HOME"), defaultAwsCredFile)),

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -38,7 +38,7 @@ const (
 	cliClientID           = "github.com-vmware-priam"
 	cliClientSecret       = "not-a-secret"
 	defaultAwsCredFile    = ".aws/credentials"
-	defaultAwsProfile     = "default"
+	defaultAwsProfile     = "priam"
 	defaultAwsStsEndpoint = "https://sts.amazonaws.com"
 )
 
@@ -600,10 +600,10 @@ func Priam(args []string, defaultCfgFile string, infoW, errorW io.Writer) {
 					},
 				},
 				{
-					Name: "aws", Usage: "Use ID token to update credentials in the AWS CLI configuration file", ArgsUsage: "<aws-role-name>",
+					Name: "aws", Usage: "Use ID token to update credentials in the AWS CLI configuration file", ArgsUsage: "<aws-role-arn>",
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "credfile, c", Usage: "name of file to store AWS credentials. Default is ~/" + defaultAwsCredFile},
-						cli.StringFlag{Name: "profile, p", Usage: "profile in which to store AWS credentials"},
+						cli.StringFlag{Name: "profile, p", Usage: "Profile in which to store AWS credentials, Default is \"priam'\"."},
 					},
 					Action: func(c *cli.Context) error {
 						if args, ctx := initCmd(cfg, c, 1, 1, false, nil); ctx != nil {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -926,16 +926,25 @@ func TestPassEmptyTokenForValidationIfNoIDTokenSaved(t *testing.T) {
 	tokenServiceMock.AssertExpectations(t)
 }
 
+const expectedAwsStsEndpoint = "https://sts.amazonaws.com"
+
 func TestCanUpdateAWSCredentialsInDefaultCredFile(t *testing.T) {
 	cfgFile := filepath.Join(os.Getenv("HOME"), ".aws/credentials")
 	tokenServiceMock := setupTokenServiceMock()
-	tokenServiceMock.On("UpdateAWSCredentials", mock.Anything, goodIdToken, cfgFile).Return(nil)
-	testMockCommand(t, &tokenServiceMock.Mock, "token", "aws")
+	tokenServiceMock.On("UpdateAWSCredentials", mock.Anything, goodIdToken, "space-hound", expectedAwsStsEndpoint, cfgFile, "default").Return(nil)
+	testMockCommand(t, &tokenServiceMock.Mock, "token", "aws", "space-hound")
 }
 
 func TestCanUpdateAWSCredentialsInExplicitCredFile(t *testing.T) {
-	cfgFile := filepath.Join(os.Getenv("HOME"), "/var/tmp/my-cred-file")
+	cfgFile := "/var/tmp/my-cred-file"
 	tokenServiceMock := setupTokenServiceMock()
-	tokenServiceMock.On("UpdateAWSCredentials", mock.Anything, goodIdToken, cfgFile).Return(nil)
-	testMockCommand(t, &tokenServiceMock.Mock, "token", "aws", cfgFile)
+	tokenServiceMock.On("UpdateAWSCredentials", mock.Anything, goodIdToken, "space-messenger", expectedAwsStsEndpoint, cfgFile, "default").Return(nil)
+	testMockCommand(t, &tokenServiceMock.Mock, "token", "aws", "-c", cfgFile, "space-messenger")
+}
+
+func TestCanUpdateAWSCredentialsInExplicitCredFileAndProfile(t *testing.T) {
+	cfgFile := "/var/tmp/my-cred-file"
+	tokenServiceMock := setupTokenServiceMock()
+	tokenServiceMock.On("UpdateAWSCredentials", mock.Anything, goodIdToken, "space-hound", expectedAwsStsEndpoint, cfgFile, "kazak").Return(nil)
+	testMockCommand(t, &tokenServiceMock.Mock, "token", "aws", "-c", cfgFile, "-p", "kazak", "space-hound")
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -887,7 +887,7 @@ func TestCanListClients(t *testing.T) {
 }
 
 func TestCanRegisterCliClient(t *testing.T) {
-	expectedCliClientRegistration := map[string]interface{}{"clientId": cliClientID, "secret": cliClientSecret,
+	expectedCliClientRegistration := map[string]interface{}{"clientId": "github.com-vmware-priam", "secret": "not-a-secret",
 		"accessTokenTTL": 60 * 60, "authGrantTypes": "authorization_code refresh_token", "displayUserGrant": false,
 		"redirectUri": TokenCatcherURI, "refreshTokenTTL": 60 * 60 * 24 * 30, "scope": "openid user profile email admin"}
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -931,14 +931,14 @@ const expectedAwsStsEndpoint = "https://sts.amazonaws.com"
 func TestCanUpdateAWSCredentialsInDefaultCredFile(t *testing.T) {
 	cfgFile := filepath.Join(os.Getenv("HOME"), ".aws/credentials")
 	tokenServiceMock := setupTokenServiceMock()
-	tokenServiceMock.On("UpdateAWSCredentials", mock.Anything, goodIdToken, "space-hound", expectedAwsStsEndpoint, cfgFile, "default").Return(nil)
+	tokenServiceMock.On("UpdateAWSCredentials", mock.Anything, goodIdToken, "space-hound", expectedAwsStsEndpoint, cfgFile, "priam").Return(nil)
 	testMockCommand(t, &tokenServiceMock.Mock, "token", "aws", "space-hound")
 }
 
 func TestCanUpdateAWSCredentialsInExplicitCredFile(t *testing.T) {
 	cfgFile := "/var/tmp/my-cred-file"
 	tokenServiceMock := setupTokenServiceMock()
-	tokenServiceMock.On("UpdateAWSCredentials", mock.Anything, goodIdToken, "space-messenger", expectedAwsStsEndpoint, cfgFile, "default").Return(nil)
+	tokenServiceMock.On("UpdateAWSCredentials", mock.Anything, goodIdToken, "space-messenger", expectedAwsStsEndpoint, cfgFile, "priam").Return(nil)
 	testMockCommand(t, &tokenServiceMock.Mock, "token", "aws", "-c", cfgFile, "space-messenger")
 }
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -28,6 +28,8 @@ import (
 	. "github.com/vmware/priam/testaid"
 	. "github.com/vmware/priam/util"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -922,4 +924,18 @@ func TestPassEmptyTokenForValidationIfNoIDTokenSaved(t *testing.T) {
 	serverTarget := fmt.Sprintf("%s    accesstokentype: Bearer\n    accesstoken: %s\n", tstSrvTgt("http://no.id.token.site"), goodAccessToken)
 	runner(newTstCtx(t, serverTarget), "token", "validate")
 	tokenServiceMock.AssertExpectations(t)
+}
+
+func TestCanUpdateAWSCredentialsInDefaultCredFile(t *testing.T) {
+	cfgFile := filepath.Join(os.Getenv("HOME"), ".aws/credentials")
+	tokenServiceMock := setupTokenServiceMock()
+	tokenServiceMock.On("UpdateAWSCredentials", mock.Anything, goodIdToken, cfgFile).Return(nil)
+	testMockCommand(t, &tokenServiceMock.Mock, "token", "aws")
+}
+
+func TestCanUpdateAWSCredentialsInExplicitCredFile(t *testing.T) {
+	cfgFile := filepath.Join(os.Getenv("HOME"), "/var/tmp/my-cred-file")
+	tokenServiceMock := setupTokenServiceMock()
+	tokenServiceMock.On("UpdateAWSCredentials", mock.Anything, goodIdToken, cfgFile).Return(nil)
+	testMockCommand(t, &tokenServiceMock.Mock, "token", "aws", cfgFile)
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -887,8 +887,12 @@ func TestCanListClients(t *testing.T) {
 }
 
 func TestCanRegisterCliClient(t *testing.T) {
+	expectedCliClientRegistration := map[string]interface{}{"clientId": cliClientID, "secret": cliClientSecret,
+		"accessTokenTTL": 60 * 60, "authGrantTypes": "authorization_code refresh_token", "displayUserGrant": false,
+		"redirectUri": TokenCatcherURI, "refreshTokenTTL": 60 * 60 * 24 * 30, "scope": "openid user profile email admin"}
+
 	clntServiceMock := setupClientServiceMock()
-	clntServiceMock.On("Add", mock.Anything, cliClientID, cliClientRegistration).Return()
+	clntServiceMock.On("Add", mock.Anything, cliClientID, expectedCliClientRegistration).Return()
 	testMockCommand(t, &clntServiceMock.Mock, "client", "register")
 }
 

--- a/core/token.go
+++ b/core/token.go
@@ -278,7 +278,7 @@ func (ts TokenService) UpdateAWSCredentials(log *Logr, idToken, role, stsURL, cr
 		if err := saveCredFile(awsCfg, credFile); err != nil {
 			log.Err("Could not update AWS credentials file \"%s\": %v\n", credFile, err)
 		} else {
-			log.Info("Successfully updated AWS credentials file: %s", credFile)
+			log.Info("Successfully updated AWS credentials file: %s\n", credFile)
 		}
 	}
 }

--- a/core/token.go
+++ b/core/token.go
@@ -226,7 +226,7 @@ func (ts TokenService) ValidateIDToken(ctx *HttpContext, idToken string) {
 
 var awsStsEndpoint = "https://sts.amazonaws.com"
 
-// exchange and ID token for AWS credentials and update tthem in the credFIle
+// exchange an ID token for AWS credentials and update them in the credFIle
 func (ts TokenService) UpdateAWSCredentials(ctx *HttpContext, idToken, credFile string) {
 	if idToken == "" {
 		ctx.Log.Err("No ID token provided.")
@@ -238,8 +238,9 @@ func (ts TokenService) UpdateAWSCredentials(ctx *HttpContext, idToken, credFile 
 	vals.Set("Action", "AssumeRoleWithWebIdentity")
 	vals.Set("DurationSeconds", "3600")
 	vals.Set("RoleSessionName", ts.CliClientID)
-	vals.Set("RoleArn", "arn:aws:iam::123456789012:role/FederatedWebIdentityRole")
+	vals.Set("RoleArn", "arn:aws:iam::044114111530:role/vidmIdentity")
 	vals.Set("WebIdentityToken", idToken)
+	vals.Set("Version", "2011-06-15")
 	actx := NewHttpContext(ctx.Log, awsStsEndpoint, "", "")
 	path := fmt.Sprintf("?%v", vals.Encode())
 	outp := ""
@@ -248,4 +249,5 @@ func (ts TokenService) UpdateAWSCredentials(ctx *HttpContext, idToken, credFile 
 	} else {
 		ctx.Log.Info("AWS response:\n%s\n", outp)
 	}
+
 }

--- a/core/token.go
+++ b/core/token.go
@@ -278,7 +278,7 @@ func (ts TokenService) UpdateAWSCredentials(log *Logr, idToken, role, stsURL, cr
 		if err := saveCredFile(awsCfg, credFile); err != nil {
 			log.Err("Could not update AWS credentials file \"%s\": %v\n", credFile, err)
 		} else {
-			log.Info("Successfully updated AWS credentials file")
+			log.Info("Successfully updated AWS credentials file: %s", credFile)
 		}
 	}
 }

--- a/core/token.go
+++ b/core/token.go
@@ -244,7 +244,7 @@ func (ts TokenService) UpdateAWSCredentials(log *Logr, idToken, role, stsURL, cr
 	vals.Set("Action", "AssumeRoleWithWebIdentity")
 	vals.Set("DurationSeconds", "3600")
 	vals.Set("RoleSessionName", ts.CliClientID)
-	vals.Set("RoleArn", "arn:aws:iam::044114111530:role/"+role)
+	vals.Set("RoleArn", role)
 	vals.Set("WebIdentityToken", idToken)
 	vals.Set("Version", "2011-06-15")
 	if err := actx.Request("GET", fmt.Sprintf("?%v", vals.Encode()), nil, &outp); err != nil {

--- a/core/token.go
+++ b/core/token.go
@@ -19,11 +19,13 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/toqueteos/webbrowser"
 	. "github.com/vmware/priam/util"
+	"gopkg.in/ini.v1"
 	"io"
 	"net"
 	"net/http"
@@ -43,14 +45,13 @@ type TokenInfo struct {
 	ExpiresIn       int    `json:"expires_in,omitempty"`
 }
 
-// Interface to get tokens via OAuth2 grants and system user login API
-// and validate them.
+// Interface to get tokens via OAuth2 grants, system user login API, and validate them.
 type TokenGrants interface {
 	ClientCredentialsGrant(ctx *HttpContext, clientID, clientSecret string) (TokenInfo, error)
 	LoginSystemUser(ctx *HttpContext, user, password string) (TokenInfo, error)
 	AuthCodeGrant(ctx *HttpContext, userHint string) (TokenInfo, error)
 	ValidateIDToken(ctx *HttpContext, idToken string)
-	UpdateAWSCredentials(ctx *HttpContext, idToken, credFile string)
+	UpdateAWSCredentials(log *Logr, idToken, role, stsURL, credFile, profile string)
 }
 
 type TokenService struct{ AuthorizePath, TokenPath, LoginPath, CliClientID, CliClientSecret string }
@@ -224,30 +225,60 @@ func (ts TokenService) ValidateIDToken(ctx *HttpContext, idToken string) {
 	}
 }
 
-var awsStsEndpoint = "https://sts.amazonaws.com"
+// define cred file handlers so that they can be stubbed for testing
+var saveCredFile = func(f *ini.File, fileName string) error { return f.SaveTo(fileName) }
+var updateKeyInCredFile = func(f *ini.File, section, key, value string) error {
+	_, err := f.Section(section).NewKey(key, value)
+	return err
+}
 
-// exchange an ID token for AWS credentials and update them in the credFIle
-func (ts TokenService) UpdateAWSCredentials(ctx *HttpContext, idToken, credFile string) {
+// exchange an ID token for AWS credentials and update them in the credFile
+func (ts TokenService) UpdateAWSCredentials(log *Logr, idToken, role, stsURL, credFile, profile string) {
 	if idToken == "" {
-		ctx.Log.Err("No ID token provided.")
+		log.Err("No ID token provided.")
 		return
 	}
 
 	// set up and make call to aws sts
-	vals := make(url.Values)
+	actx, vals, outp := NewHttpContext(log, stsURL, "/", ""), make(url.Values), ""
 	vals.Set("Action", "AssumeRoleWithWebIdentity")
 	vals.Set("DurationSeconds", "3600")
 	vals.Set("RoleSessionName", ts.CliClientID)
-	vals.Set("RoleArn", "arn:aws:iam::044114111530:role/vidmIdentity")
+	vals.Set("RoleArn", "arn:aws:iam::044114111530:role/"+role)
 	vals.Set("WebIdentityToken", idToken)
 	vals.Set("Version", "2011-06-15")
-	actx := NewHttpContext(ctx.Log, awsStsEndpoint, "", "")
-	path := fmt.Sprintf("?%v", vals.Encode())
-	outp := ""
-	if err := actx.Request("GET", path, nil, &outp); err != nil {
-		ctx.Log.Err("Error getting AWS credentials: %v\n", err)
-	} else {
-		ctx.Log.Info("AWS response:\n%s\n", outp)
+	if err := actx.Request("GET", fmt.Sprintf("?%v", vals.Encode()), nil, &outp); err != nil {
+		log.Err("Error getting AWS credentials: %v\n", err)
+		return
 	}
 
+	// extract credentials from XML response
+	creds := struct {
+		SessionToken    string `xml:"AssumeRoleWithWebIdentityResult>Credentials>SessionToken"`
+		SecretAccessKey string `xml:"AssumeRoleWithWebIdentityResult>Credentials>SecretAccessKey"`
+		AccessKeyId     string `xml:"AssumeRoleWithWebIdentityResult>Credentials>AccessKeyId"`
+	}{}
+	if err := xml.Unmarshal([]byte(outp), &creds); err != nil {
+		log.Err("Error extracting credentials from AWS STS response: %v\n", err)
+		return
+	}
+
+	// save credentials in the specified AWS CLI credentials file
+	ini.PrettyFormat = false // we're updating someone's aws config file, don't mess it up.
+	if awsCfg, err := ini.LooseLoad(credFile); err != nil {
+		log.Err("Error loading AWS CLI credentials file \"%s\": %v\n", credFile, err)
+	} else {
+		for k, v := range map[string]string{"aws_access_key_id": creds.AccessKeyId,
+			"aws_secret_access_key": creds.SecretAccessKey, "aws_session_token": creds.SessionToken} {
+			if err := updateKeyInCredFile(awsCfg, profile, k, v); err != nil {
+				log.Err("Error updating credential in section \"%s\" of file \"%s\": %v", profile, credFile, err)
+				return
+			}
+		}
+		if err := saveCredFile(awsCfg, credFile); err != nil {
+			log.Err("Could not update AWS credentials file \"%s\": %v\n", credFile, err)
+		} else {
+			log.Info("Successfully updated AWS credentials file")
+		}
+	}
 }

--- a/core/token_test.go
+++ b/core/token_test.go
@@ -393,16 +393,15 @@ const sampleResponse = `
   </ResponseMetadata>
 </AssumeRoleWithWebIdentityResponse>`
 
-type AssumeRoleWithWebIdentityResult struct {
-	SubjectFromWebIdentityToken, Audience, Provider string
-}
-
 type AssumeRoleWithWebIdentityResponse struct {
-	result AssumeRoleWithWebIdentityResult
+	SessionToken    string `xml:"AssumeRoleWithWebIdentityResult>Credentials>SessionToken"`
+	SecretAccessKey string `xml:"AssumeRoleWithWebIdentityResult>Credentials>SecretAccessKey"`
+	AccessKeyId     string `xml:"AssumeRoleWithWebIdentityResult>Credentials>AccessKeyId"`
 }
 
 func TestParseXML(t *testing.T) {
 	var output AssumeRoleWithWebIdentityResponse
+
 	err := xml.Unmarshal([]byte(sampleResponse), &output)
 	assert.Nil(t, err)
 	fmt.Printf("output:\n%#v\n", output)

--- a/core/token_test.go
+++ b/core/token_test.go
@@ -535,7 +535,7 @@ aws_session_token=good-session-token
 	cfgFile := WriteTempFile(t, "")
 	CleanupTempFile(cfgFile)
 	testTS.UpdateAWSCredentials(ctx.Log, goodIdToken, goodAwsRole, srv.URL, cfgFile.Name(), "roomsford")
-	AssertOnlyInfoContains(t, ctx, "Successfully updated AWS credentials file")
+	AssertOnlyInfoContains(t, ctx, "Successfully updated AWS credentials file: "+cfgFile.Name())
 
 	// check aws credentials file contents
 	contents, err := ioutil.ReadFile(cfgFile.Name())

--- a/core/token_test.go
+++ b/core/token_test.go
@@ -366,7 +366,7 @@ func awsStsQueryString(role, idToken string) string {
 	vals.Set("Action", "AssumeRoleWithWebIdentity")
 	vals.Set("DurationSeconds", "3600")
 	vals.Set("RoleSessionName", testTS.CliClientID)
-	vals.Set("RoleArn", "arn:aws:iam::044114111530:role/"+role)
+	vals.Set("RoleArn", role)
 	vals.Set("WebIdentityToken", idToken)
 	vals.Set("Version", "2011-06-15")
 	return fmt.Sprintf("?%v", vals.Encode())
@@ -422,8 +422,7 @@ func awsStsResponse(accessKeyId, accessKey, sessionToken string) string {
 }
 
 const (
-	goodAwsRole      = "space-hound"
-	badAwsRole       = "tralfamadorian"
+	goodAwsRole      = "arn:aws:iam::044114111530:role/space-hound"
 	goodIdToken      = "kazak.the.hound.of.space"
 	goodAwsProfile   = "kazak"
 	goodKeyId        = "thisIsAGoodKeyID"


### PR DESCRIPTION
NOTE: This has not been manually tested yet as I do not have access to a vIDM instance with service side fixes that is federated to AWS. Checking in now in hopes someone else can test or loan a test environment.  

The change adds a command to exchange an id token for aws credentials

1. Adds "token aws" command to exchange an ID token for temporary credentials via the AWS STS using the AssumeRoleWithWebIdentity action.
2. An AWS role must be given
3. Credentials are written to the AWS CLI credentials file, or other specified file.
4. An AWS CLI Profile can be specified. 

Testing done: unit tests
