### PR TITLE
Fix compilation error with new version of cli library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,8 @@ cover: coverage
 install:
 	$(GO) install
 
+# since priam packages are installed as libraries in the golang pkg directory we must 
+# specifially clean each package with the -i (installed) option. 
 clean:
 	$(GO) clean -i . ./cli ./core ./mocks ./testaid ./util
 	rm -rf mocks/*

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ install:
 	$(GO) install
 
 clean:
-	$(GO) clean
+	$(GO) clean -i . ./cli ./core ./mocks ./testaid ./util
 	rm -rf mocks/*
 
 help:

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -224,7 +224,7 @@ func cmdWithAuth0Arg(cfg *Config, cmd func(*HttpContext)) func(c *cli.Context) e
 func Priam(args []string, defaultCfgFile string, infoW, errorW io.Writer) {
 	var err error
 	cfg := &Config{}
-	cli.HelpFlag.Usage = "show help for given command or subcommand"
+	//cli.HelpFlag = cli.BoolFlag{Name: "help, h", Usage: "show help for given command or subcommand"}
 
 	// work around error in cli v1.18 by setting package level ErrWriter since
 	// app level ErrWriter is ignored for some deprecation warnings.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -224,7 +224,6 @@ func cmdWithAuth0Arg(cfg *Config, cmd func(*HttpContext)) func(c *cli.Context) e
 func Priam(args []string, defaultCfgFile string, infoW, errorW io.Writer) {
 	var err error
 	cfg := &Config{}
-	//cli.HelpFlag = cli.BoolFlag{Name: "help, h", Usage: "show help for given command or subcommand"}
 
 	// work around error in cli v1.18 by setting package level ErrWriter since
 	// app level ErrWriter is ignored for some deprecation warnings.


### PR DESCRIPTION
* A new version of the urfave/cli library changed how help text for global
  options can be overridden. Worked around the compile error
* make clean was not removing the library (*.a) files from the pkg area
  so 'make' after 'make clean' did not rebuild all packages. Fixed in
  the makefile.