### PR TITLE
Apps: add ability to specify complex authInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,15 @@ applications:
       audience: "https://test.fanny.audience"
       assertionConsumerServiceUrl: "https://test.fanny/a/{domainName}/acs?RelayState=http://mail.google.com/a/{domainName}"
       recipientName: "https://test.fanny/a/{domainName}/acs"
+      attributes:
+      - name: https://aws.amazon.com/SAML/Attributes/Role
+        nameFormat: urn:oasis:names:tc:SAML:2.0:attrname-format:uri
+        nameSpace: ''
+        value: arn:aws:iam::646585102600:role/MyRole,arn:aws:iam::12345678:saml-provider/my-org
+      - name: https://aws.amazon.com/SAML/Attributes/RoleSessionName
+        nameFormat: urn:oasis:names:tc:SAML:2.0:attrname-format:uri
+        nameSpace: ''
+        value: "${user.userName}"
 ```
 
 ## Contributing


### PR DESCRIPTION
authInfo contains the "attributes" field which
is an array of maps and was not supported with
the regular map mapping, so added a custom JSON'
marshaller to be able to add those apps.

Testing Done: make
+ ./priam add app aws-app.yaml
where aws-app.yaml contains uner authInfo:

[...]
attributes:
      - name: https://aws.amazon.com/SAML/Attributes/Role
        nameFormat: urn:oasis:names:tc:SAML:2.0:attrname-format:uri
        nameSpace: ''
        value: arn:aws:iam::646585102600:role/SuperAdminRole,arn:aws:iam::646585102600:saml-provider/ops-staging
      - name: https://aws.amazon.com/SAML/Attributes/RoleSessionName
        nameFormat: urn:oasis:names:tc:SAML:2.0:attrname-format:uri
        nameSpace: ''
[...]

Bug Number:
Reviewed by:
Review URL: