### PR TITLE
vRA: support tenant in path mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ generate-mocks: build-testaid
 	$(GOPATH)/bin/mockery -dir=core -name=ApplicationService
 	$(GOPATH)/bin/mockery -dir=core -name=OauthResource
 	$(GOPATH)/bin/mockery -dir=core -name=TokenGrants
+	$(GOPATH)/bin/mockery -dir=core -name=TokenServiceFactory
 
 test: update-build-dependencies generate-mocks
 	@echo testing...

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	vidmBasePath          = "/SAAS/jersey/manager/api/"
+	vidmBasePath          = "/jersey/manager/api/"
 	vidmBaseMediaType     = "application/vnd.vmware.horizon.manager."
 	accessTokenOption     = "accesstoken"
 	accessTokenTypeOption = "accesstokentype"
@@ -65,13 +65,7 @@ var rolesService DirectoryService = &SCIMRolesService{}
 var appsService ApplicationService = &IDMApplicationService{}
 var templateService OauthResource = AppTemplateService
 var clientService OauthResource = OauthClientService
-
-var tokenService TokenGrants = TokenService{
-	AuthorizePath:   "/SAAS/auth/oauth2/authorize",
-	TokenPath:       "/SAAS/auth/oauthtoken",
-	LoginPath:       "/SAAS/API/1.0/REST/auth/system/login",
-	CliClientID:     cliClientID,
-	CliClientSecret: cliClientSecret}
+var tokenServiceFactory TokenServiceFactory = &TokenServiceFactoryImpl{}
 
 var getRawPassword = gopass.GetPasswd // called via variable so that tests can provide stub
 var consoleInput io.Reader = os.Stdin // will be set to other readers for tests
@@ -115,7 +109,11 @@ func InitCtx(cfg *Config, authn bool) *HttpContext {
 		cfg.Log.Err("Error: no target set\n")
 		return nil
 	}
-	ctx := NewHttpContext(cfg.Log, cfg.Option(HostOption), vidmBasePath, vidmBaseMediaType)
+	basePath := vidmBasePath
+	if cfg.IsTenantInUrl() {
+		basePath = "/SAAS" + vidmBasePath
+	}
+	ctx := NewHttpContext(cfg.Log, cfg.Option(HostOption), basePath, vidmBaseMediaType)
 	if authn {
 		if token := cfg.Option(accessTokenOption); token == "" {
 			cfg.Log.Err("No access token saved for current target. Please log in.\n")
@@ -175,7 +173,7 @@ func checkTarget(cfg *Config) bool {
 		return false
 	}
 	if err := ctx.Request("GET", "health", nil, &output); err != nil {
-		ctx.Log.Err("Error checking health of %s: \n", ctx.HostURL)
+		ctx.Log.Err("Error checking health of %s: %v\n", ctx.HostURL, err)
 		return false
 	}
 	ctx.Log.Debug("health check output:\n%s\n", output)
@@ -436,6 +434,7 @@ func Priam(args []string, defaultCfgFile string, infoW, errorW io.Writer) {
 			Action: func(c *cli.Context) (err error) {
 				if a, ctx := initCmd(cfg, c, 0, 2, false, nil); ctx != nil {
 					tokenInfo := TokenInfo{}
+					tokenService := tokenServiceFactory.GetTokenService(cfg, cliClientID, cliClientSecret)
 					if c.Bool("authcode") {
 						if tokenInfo, err = tokenService.AuthCodeGrant(ctx, a[0]); err != nil {
 							cfg.Log.Err("Error getting tokens via browser: %v\n", err)
@@ -593,6 +592,7 @@ func Priam(args []string, defaultCfgFile string, infoW, errorW io.Writer) {
 					Name: "validate", Usage: "validate the current ID token (if logged in)", ArgsUsage: " ",
 					Action: func(c *cli.Context) error {
 						if _, ctx := initCmd(cfg, c, 0, 0, true, nil); ctx != nil {
+							tokenService := tokenServiceFactory.GetTokenService(cfg, cliClientID, cliClientSecret)
 							tokenService.ValidateIDToken(ctx, cfg.Option(idTokenOption))
 						}
 						return nil
@@ -606,6 +606,7 @@ func Priam(args []string, defaultCfgFile string, infoW, errorW io.Writer) {
 					},
 					Action: func(c *cli.Context) error {
 						if args, ctx := initCmd(cfg, c, 1, 1, false, nil); ctx != nil {
+							tokenService := tokenServiceFactory.GetTokenService(cfg, cliClientID, cliClientSecret)
 							tokenService.UpdateAWSCredentials(ctx.Log, cfg.Option(idTokenOption),
 								args[0], defaultAwsStsEndpoint,
 								StringOrDefault(c.String("credfile"), filepath.Join(os.Getenv("HOME"), defaultAwsCredFile)),

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -110,7 +110,7 @@ func InitCtx(cfg *Config, authn bool) *HttpContext {
 		return nil
 	}
 	basePath := vidmBasePath
-	if cfg.IsTenantInUrl() {
+	if cfg.IsTenantInHost() {
 		basePath = "/SAAS" + vidmBasePath
 	}
 	ctx := NewHttpContext(cfg.Log, cfg.Option(HostOption), basePath, vidmBaseMediaType)

--- a/core/apps.go
+++ b/core/apps.go
@@ -34,20 +34,20 @@ type IDMApplicationService struct {
 }
 
 type priamApp struct {
-	Name                  string                 `json:"name,omitempty" yaml:"name,omitempty"`
-	Uuid                  string                 `json:"uuid,omitempty" yaml:"uuid,omitempty"`
-	PackageVersion        string                 `json:"packageVersion,omitempty" yaml:"packageVersion,omitempty"`
-	Description           string                 `json:"description,omitempty" yaml:"description,omitempty"`
-	IconFile              string                 `json:"iconFile,omitempty" yaml:"iconFile,omitempty"`
-	EntitleGroup          string                 `json:"entitleGroup,omitempty" yaml:"entitleGroup,omitempty"`
-	EntitleUser           string                 `json:"entitleUser,omitempty" yaml:"entitleUser,omitempty"`
-	ResourceConfiguration map[string]interface{} `json:"resourceConfiguration" yaml:"resourceConfiguration,omitempty"`
-	AccessPolicy          string                 `json:"accessPolicy,omitempty" yaml:"accessPolicy,omitempty"`
-	AccessPolicySetUuid   string                 `json:"accessPolicySetUuid,omitempty" yaml:"accessPolicySetUuid,omitempty"`
-	CatalogItemType       string                 `json:"catalogItemType,omitempty" yaml:"catalogItemType,omitempty"`
-	JsonTester            jsonMarshalTester      `json:"jsonTester,omitempty" yaml:"jsonTester,omitempty"`
-	Labels                []string               `json:"labels,omitempty" yaml:"labels,omitempty"`
-	AuthInfo              authInfo               `json:"authInfo,omitempty" yaml:"authInfo,omitempty"`
+	Name                  string                   `json:"name,omitempty" yaml:"name,omitempty"`
+	Uuid                  string                   `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	PackageVersion        string                   `json:"packageVersion,omitempty" yaml:"packageVersion,omitempty"`
+	Description           string                   `json:"description,omitempty" yaml:"description,omitempty"`
+	IconFile              string                   `json:"iconFile,omitempty" yaml:"iconFile,omitempty"`
+	EntitleGroup          string                   `json:"entitleGroup,omitempty" yaml:"entitleGroup,omitempty"`
+	EntitleUser           string                   `json:"entitleUser,omitempty" yaml:"entitleUser,omitempty"`
+	ResourceConfiguration map[string]interface{}   `json:"resourceConfiguration" yaml:"resourceConfiguration,omitempty"`
+	AccessPolicy          string                   `json:"accessPolicy,omitempty" yaml:"accessPolicy,omitempty"`
+	AccessPolicySetUuid   string                   `json:"accessPolicySetUuid,omitempty" yaml:"accessPolicySetUuid,omitempty"`
+	CatalogItemType       string                   `json:"catalogItemType,omitempty" yaml:"catalogItemType,omitempty"`
+	JsonTester            jsonMarshalTester        `json:"jsonTester,omitempty" yaml:"jsonTester,omitempty"`
+	Labels                []map[string]interface{} `json:"labels,omitempty" yaml:"labels,omitempty"`
+	AuthInfo              authInfo                 `json:"authInfo,omitempty" yaml:"authInfo,omitempty"`
 }
 
 // Create a different auth info to be able to marshal special nested values in the map (other than string)

--- a/core/tokenservicefactory.go
+++ b/core/tokenservicefactory.go
@@ -1,0 +1,49 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	. "github.com/vmware/priam/util"
+)
+
+// default implementation of the factory
+type TokenServiceFactoryImpl struct{}
+
+/* Factory that we can mock to return the right token service */
+type TokenServiceFactory interface {
+	GetTokenService(cfg *Config, cliClientID string, cliClientSecret string) TokenGrants
+}
+
+func (factory TokenServiceFactoryImpl) GetTokenService(cfg *Config, cliClientID string, cliClientSecret string) TokenGrants {
+	if cfg.IsTenantInUrl() {
+		return TokenService{
+			BasePath:        "/SAAS",
+			AuthorizePath:   "/auth/oauth2/authorize",
+			TokenPath:       "/auth/oauthtoken",
+			LoginPath:       "/API/1.0/REST/auth/system/login",
+			CliClientID:     cliClientID,
+			CliClientSecret: cliClientSecret}
+	}
+	// Note: defining a base yoken service structure to avoid copy/pasting the same values
+	// for AuthorizePath, tokenPath, ... did not pass "go vet": "composite literal uses unkeyed fields"
+	return TokenService{
+		BasePath:        "",
+		AuthorizePath:   "/auth/oauth2/authorize",
+		TokenPath:       "/auth/oauthtoken",
+		LoginPath:       "/API/1.0/REST/auth/system/login",
+		CliClientID:     cliClientID,
+		CliClientSecret: cliClientSecret}
+}

--- a/core/tokenservicefactory.go
+++ b/core/tokenservicefactory.go
@@ -28,7 +28,7 @@ type TokenServiceFactory interface {
 }
 
 func (factory TokenServiceFactoryImpl) GetTokenService(cfg *Config, cliClientID string, cliClientSecret string) TokenGrants {
-	if cfg.IsTenantInUrl() {
+	if cfg.IsTenantInHost() {
 		return TokenService{
 			BasePath:        "/SAAS",
 			AuthorizePath:   "/auth/oauth2/authorize",

--- a/core/tokenservicefactory_test.go
+++ b/core/tokenservicefactory_test.go
@@ -23,10 +23,10 @@ import (
 
 func TestTenantInUrlTokenService(t *testing.T) {
 	factory := &TokenServiceFactoryImpl{}
-	cfg := configFor(TenantInUrl)
+	cfg := configFor(TenantInHost)
 	cfg.CurrentTarget = "current"
 	cfg.Targets = make(map[string]map[string]string)
-	cfg.Targets[cfg.CurrentTarget] = map[string]string{HostOption: "full-url", HostMode: "tenant-in-url"}
+	cfg.Targets[cfg.CurrentTarget] = map[string]string{HostOption: "full-url", HostMode: "tenant-in-host"}
 
 	svc, ok := factory.GetTokenService(cfg, "id", "secret").(TokenService)
 

--- a/core/tokenservicefactory_test.go
+++ b/core/tokenservicefactory_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"github.com/stretchr/testify/assert"
+	. "github.com/vmware/priam/util"
+	"testing"
+)
+
+func TestTenantInUrlTokenService(t *testing.T) {
+	factory := &TokenServiceFactoryImpl{}
+	cfg := configFor(TenantInUrl)
+	cfg.CurrentTarget = "current"
+	cfg.Targets = make(map[string]map[string]string)
+	cfg.Targets[cfg.CurrentTarget] = map[string]string{HostOption: "full-url", HostMode: "tenant-in-url"}
+
+	svc, ok := factory.GetTokenService(cfg, "id", "secret").(TokenService)
+
+	assert.True(t, ok, "should get back a TokenService object")
+	assert.Equal(t, "/SAAS", svc.BasePath)
+}
+
+func TestTenantInPathTokenService(t *testing.T) {
+	factory := &TokenServiceFactoryImpl{}
+	cfg := configFor(TenantInPath)
+
+	svc, ok := factory.GetTokenService(cfg, "id", "secret").(TokenService)
+
+	assert.True(t, ok, "should get back a TokenService object")
+	assert.Equal(t, "", svc.BasePath)
+}
+
+func configFor(mode string) *Config {
+	cfg := &Config{}
+	cfg.CurrentTarget = "current"
+	cfg.Targets = make(map[string]map[string]string)
+	cfg.Targets[cfg.CurrentTarget] = map[string]string{HostOption: "full-url", HostMode: mode}
+	return cfg
+}

--- a/testaid/http.go
+++ b/testaid/http.go
@@ -50,7 +50,7 @@ func StartTstServer(t *testing.T, paths map[string]TstHandler) *httptest.Server 
 			http.Error(w, fmt.Sprintf("error reading request body: %v", err), 404)
 		} else if handler, ok := paths[r.Method+r.URL.String()]; !ok {
 			http.Error(w, fmt.Sprintf("unknown path: %v", r.Method+r.URL.String()), 404)
-			t.Errorf("unknown path: %v", r.Method+r.URL.String())
+			t.Errorf("unknown path: %v\nregistered paths are: %v", r.Method+r.URL.String(), paths)
 		} else {
 			reply := handler(t, &TstReq{r.Header.Get("Accept"),
 				r.Header.Get("Content-Type"), r.Header.Get("Authorization"),

--- a/util/config.go
+++ b/util/config.go
@@ -27,8 +27,15 @@ import (
 const NoTarget = ""
 const HostOption = "host"
 
+/* Host modes definitions. */
+const HostMode = "mode"
+const (
+	TenantInUrl  = "tenant-in-url"
+	TenantInPath = "tenant-in-path"
+)
+
 /* Config represents a set of named targets, with an indication of which target is currently
-   active. Each target contains a map of options. The only option known to this code is HostOption,
+   active. Each target contains a map of options. The only options known to this code are HostOption, HostMode
    all other options are up to the users of the config struct.
 */
 type Config struct {
@@ -137,6 +144,13 @@ func ensureFullURL(url string) string {
 	return "https://" + url
 }
 
+// Returns true if the current vIDM targeted is in url in path mode
+// If no host mode has been set (previous behaviour), then consider
+// "tenant in URL" mode.
+func (cfg *Config) IsTenantInUrl() bool {
+	return cfg.Option(HostMode) == TenantInUrl || cfg.Option(HostMode) == ""
+}
+
 // findTarget attempts to find an existing target based on user input. User
 // may specify a target as a url followed by an optional name, or with no input
 // to specify the current target. findTarget returns the name of any existing
@@ -204,9 +218,16 @@ func (cfg *Config) SetTarget(url, name string, checkURL func(*Config) bool) {
 		}
 	}
 
+	// check tenant in path mode or not
+	hostMode := TenantInUrl
+	if strings.Contains(url, "/SAAS/t/") {
+		hostMode = TenantInPath
+	}
+
 	cfg.CurrentTarget = name
-	cfg.Targets[cfg.CurrentTarget] = map[string]string{HostOption: ensureFullURL(url)}
+	cfg.Targets[cfg.CurrentTarget] = map[string]string{HostOption: ensureFullURL(url), HostMode: hostMode}
 	if (checkURL == nil || checkURL(cfg)) && cfg.Save() {
+		cfg.Log.Info("Mode detected: %s\n", hostMode)
 		cfg.PrintTarget("new")
 	}
 }

--- a/util/config.go
+++ b/util/config.go
@@ -30,7 +30,7 @@ const HostOption = "host"
 /* Host modes definitions. */
 const HostMode = "mode"
 const (
-	TenantInUrl  = "tenant-in-url"
+	TenantInHost = "tenant-in-host"
 	TenantInPath = "tenant-in-path"
 )
 
@@ -144,11 +144,10 @@ func ensureFullURL(url string) string {
 	return "https://" + url
 }
 
-// Returns true if the current vIDM targeted is in url in path mode
-// If no host mode has been set (previous behaviour), then consider
-// "tenant in URL" mode.
-func (cfg *Config) IsTenantInUrl() bool {
-	return cfg.Option(HostMode) == TenantInUrl || cfg.Option(HostMode) == ""
+// Returns true if the current vIDM targeted is set to use the host part of the URL to determine the tenant name
+// If no host mode has been set (previous behaviour), then consider we are in "tenant in host" mode.
+func (cfg *Config) IsTenantInHost() bool {
+	return cfg.Option(HostMode) != TenantInPath || cfg.Option(HostMode) == ""
 }
 
 // findTarget attempts to find an existing target based on user input. User
@@ -219,7 +218,7 @@ func (cfg *Config) SetTarget(url, name string, checkURL func(*Config) bool) {
 	}
 
 	// check tenant in path mode or not
-	hostMode := TenantInUrl
+	hostMode := TenantInHost
 	if strings.Contains(url, "/SAAS/t/") {
 		hostMode = TenantInPath
 	}

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -33,8 +33,13 @@ targets:
     host: https://space.odyssey.example.com
   1:
     host: https://venus.example.com
+    mode: tenant-in-url
   staging:
     host: https://earth.example.com
+    mode: tenant-in-path
+  beautyOnTheBeach:
+    host: https://disney.princess.com
+    mode: not-right
 `
 	cfgFile, cfg := WriteTempFile(t, testAppCfg), &Config{}
 	defer cfgFile.Close()
@@ -166,4 +171,41 @@ func TestErrorWritingConfigFile(t *testing.T) {
 	require.Nil(t, cfgFile.Chmod(0))
 	assert.False(cfg.Save())
 	assert.Contains(log.ErrString(), "could not write config file "+cfgFile.Name())
+}
+
+func TestDefaultHostModeIsTenantInUrl(t *testing.T) {
+	cfg := cfgTestSetup(t)
+	defer os.Remove(cfg.fileName)
+	cfg.SetTarget("https://space.odyssey.example.com", "familyCountDown", nil)
+	assert.True(t, cfg.IsTenantInUrl(), "default host mode should be tenant in URL")
+}
+
+func TestGetHostModeForTenantInPathFromConfig(t *testing.T) {
+	cfg := cfgTestSetup(t)
+	defer os.Remove(cfg.fileName)
+	cfg.SetTarget("https://earth.example.com", "staging", nil)
+	assert.Contains(t, cfg.Log.InfoString(), "new target is: staging")
+	assert.False(t, cfg.IsTenantInUrl(), "host mode should be tenant in path")
+}
+
+func TestGetHostModeForTenantInUrl(t *testing.T) {
+	cfg := cfgTestSetup(t)
+	defer os.Remove(cfg.fileName)
+	cfg.SetTarget("", "1", nil)
+	assert.True(t, cfg.IsTenantInUrl(), "host mode should be tenant in URL")
+}
+
+func TestUnknownModeLeadsToTenantInUrl(t *testing.T) {
+	cfg := cfgTestSetup(t)
+	defer os.Remove(cfg.fileName)
+	cfg.SetTarget("", "beautyOnTheBeach", nil)
+	assert.True(t, cfg.IsTenantInUrl(), "host mode should be tenant in URL")
+}
+
+func TestCanDetectTenantInPathMode(t *testing.T) {
+	cfg := cfgTestSetup(t)
+	defer os.Remove(cfg.fileName)
+	cfg.SetTarget("https://hello.me.com/SAAS/t/foo", "", nil)
+	assert.Contains(t, cfg.Log.InfoString(), "Mode detected: tenant-in-path")
+	assert.False(t, cfg.IsTenantInUrl(), "host mode should be tenant in path")
 }

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -33,7 +33,7 @@ targets:
     host: https://space.odyssey.example.com
   1:
     host: https://venus.example.com
-    mode: tenant-in-url
+    mode: tenant-in-host
   staging:
     host: https://earth.example.com
     mode: tenant-in-path
@@ -173,11 +173,11 @@ func TestErrorWritingConfigFile(t *testing.T) {
 	assert.Contains(log.ErrString(), "could not write config file "+cfgFile.Name())
 }
 
-func TestDefaultHostModeIsTenantInUrl(t *testing.T) {
+func TestDefaultHostModeIsTenantInHost(t *testing.T) {
 	cfg := cfgTestSetup(t)
 	defer os.Remove(cfg.fileName)
 	cfg.SetTarget("https://space.odyssey.example.com", "familyCountDown", nil)
-	assert.True(t, cfg.IsTenantInUrl(), "default host mode should be tenant in URL")
+	assert.True(t, cfg.IsTenantInHost(), "default host mode should be tenant in host")
 }
 
 func TestGetHostModeForTenantInPathFromConfig(t *testing.T) {
@@ -185,21 +185,22 @@ func TestGetHostModeForTenantInPathFromConfig(t *testing.T) {
 	defer os.Remove(cfg.fileName)
 	cfg.SetTarget("https://earth.example.com", "staging", nil)
 	assert.Contains(t, cfg.Log.InfoString(), "new target is: staging")
-	assert.False(t, cfg.IsTenantInUrl(), "host mode should be tenant in path")
+	assert.False(t, cfg.IsTenantInHost(), "host mode should be tenant in path")
 }
 
-func TestGetHostModeForTenantInUrl(t *testing.T) {
+func TestGetHostModeForTenantInHost(t *testing.T) {
 	cfg := cfgTestSetup(t)
 	defer os.Remove(cfg.fileName)
-	cfg.SetTarget("", "1", nil)
-	assert.True(t, cfg.IsTenantInUrl(), "host mode should be tenant in URL")
+	cfg.SetTarget("https://venus.example.com", "1", nil)
+	assert.Equal(t, cfg.Targets[cfg.CurrentTarget][HostMode], "tenant-in-host")
+	assert.True(t, cfg.IsTenantInHost(), "host mode should be tenant in host")
 }
 
-func TestUnknownModeLeadsToTenantInUrl(t *testing.T) {
+func TestUnknownModeLeadsToTenantInHost(t *testing.T) {
 	cfg := cfgTestSetup(t)
 	defer os.Remove(cfg.fileName)
-	cfg.SetTarget("", "beautyOnTheBeach", nil)
-	assert.True(t, cfg.IsTenantInUrl(), "host mode should be tenant in URL")
+	cfg.SetTarget("https://disney.princess.com", "beautyOnTheBeach", nil)
+	assert.True(t, cfg.IsTenantInHost(), "host mode should be tenant in host")
 }
 
 func TestCanDetectTenantInPathMode(t *testing.T) {
@@ -207,5 +208,5 @@ func TestCanDetectTenantInPathMode(t *testing.T) {
 	defer os.Remove(cfg.fileName)
 	cfg.SetTarget("https://hello.me.com/SAAS/t/foo", "", nil)
 	assert.Contains(t, cfg.Log.InfoString(), "Mode detected: tenant-in-path")
-	assert.False(t, cfg.IsTenantInUrl(), "host mode should be tenant in path")
+	assert.False(t, cfg.IsTenantInHost(), "host mode should be tenant in path")
 }

--- a/util/http.go
+++ b/util/http.go
@@ -17,6 +17,7 @@ package util
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -51,8 +52,11 @@ type HttpContext struct {
 }
 
 func NewHttpContext(log *Logr, hostURL, basePath, baseMediaType string) *HttpContext {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: false}, // @todo Add a flag to trust self-signed cert
+	}
 	return &HttpContext{Log: log, HostURL: hostURL, basePath: basePath,
-		baseMediaType: baseMediaType, headers: make(map[string]string)}
+		baseMediaType: baseMediaType, headers: make(map[string]string), client: http.Client{Transport: tr}}
 }
 
 func (ctx *HttpContext) fullMediaType(shortType string) string {


### PR DESCRIPTION
- Add a "mode" to support tenant in path
(as used by vRA), versus the default tenant in URL
mode
- The mode will be detected automatically when setting
the target as the target should be:
https://<url>/SAAS/t/<the tenant name>
- Add tests

@todo Decide how we want to update the README (may need more help from vRA to validate though in the vRA use case)

Testing Done:  $ make
+ try some commands but I do not have the vRA tenant anymore
(but checked the right URL was used)
$ ./priam -t login administrator '********'
POST request to : https://cava-pn-212-197.eng.vmware.com/SAAS/t/VSPHERE.LOCAL/API/1.0/REST/auth/system/login
request headers:
  Content-Type: application/json
  Accept: application/json
request body: {"username": "administrator", "password": "********", "issueToken": true}

-> we might need to add the domain too back?

Bug Number:
Reviewed by:
Review URL: