### PR TITLE
Apps: support any valid YAML in app manifest authInfo

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -127,6 +127,9 @@ func InitCtx(cfg *Config, authn bool) *HttpContext {
 
 func initArgs(cfg *Config, c *cli.Context, minArgs, maxArgs int, validateArgs func([]string) bool) []string {
 	args := c.Args()
+	if args == nil {
+		args = []string{}
+	}
 	if len(args) < minArgs {
 		cfg.Log.Err("\nInput Error: at least %d arguments must be given\n\n", minArgs)
 	} else if maxArgs >= 0 && len(args) > maxArgs {

--- a/core/apps.go
+++ b/core/apps.go
@@ -31,20 +31,20 @@ type IDMApplicationService struct {
 }
 
 type priamApp struct {
-	Name                  string                 `json:"name,omitempty" yaml:"name,omitempty"`
-	Uuid                  string                 `json:"uuid,omitempty" yaml:"uuid,omitempty"`
-	PackageVersion        string                 `json:"packageVersion,omitempty" yaml:"packageVersion,omitempty"`
-	Description           string                 `json:"description,omitempty" yaml:"description,omitempty"`
-	IconFile              string                 `json:"iconFile,omitempty" yaml:"iconFile,omitempty"`
-	EntitleGroup          string                 `json:"entitleGroup,omitempty" yaml:"entitleGroup,omitempty"`
-	EntitleUser           string                 `json:"entitleUser,omitempty" yaml:"entitleUser,omitempty"`
-	ResourceConfiguration map[string]interface{} `json:"resourceConfiguration" yaml:"resourceConfiguration,omitempty"`
-	AccessPolicy          string                 `json:"accessPolicy,omitempty" yaml:"accessPolicy,omitempty"`
-	AccessPolicySetUuid   string                 `json:"accessPolicySetUuid,omitempty" yaml:"accessPolicySetUuid,omitempty"`
-	CatalogItemType       string                 `json:"catalogItemType,omitempty" yaml:"catalogItemType,omitempty"`
-	JsonTester            jsonMarshalTester      `json:"jsonTester,omitempty" yaml:"jsonTester,omitempty"`
-	Labels                []string               `json:"labels,omitempty" yaml:"labels,omitempty"`
-	AuthInfo              map[string]interface{} `json:"authInfo,omitempty" yaml:"authInfo,omitempty"`
+	Name                  string                   `json:"name,omitempty" yaml:"name,omitempty"`
+	Uuid                  string                   `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	PackageVersion        string                   `json:"packageVersion,omitempty" yaml:"packageVersion,omitempty"`
+	Description           string                   `json:"description,omitempty" yaml:"description,omitempty"`
+	IconFile              string                   `json:"iconFile,omitempty" yaml:"iconFile,omitempty"`
+	EntitleGroup          string                   `json:"entitleGroup,omitempty" yaml:"entitleGroup,omitempty"`
+	EntitleUser           string                   `json:"entitleUser,omitempty" yaml:"entitleUser,omitempty"`
+	ResourceConfiguration map[string]interface{}   `json:"resourceConfiguration" yaml:"resourceConfiguration,omitempty"`
+	AccessPolicy          string                   `json:"accessPolicy,omitempty" yaml:"accessPolicy,omitempty"`
+	AccessPolicySetUuid   string                   `json:"accessPolicySetUuid,omitempty" yaml:"accessPolicySetUuid,omitempty"`
+	CatalogItemType       string                   `json:"catalogItemType,omitempty" yaml:"catalogItemType,omitempty"`
+	JsonTester            jsonMarshalTester        `json:"jsonTester,omitempty" yaml:"jsonTester,omitempty"`
+	Labels                []map[string]interface{} `json:"labels,omitempty" yaml:"labels,omitempty"`
+	AuthInfo              map[string]interface{}   `json:"authInfo,omitempty" yaml:"authInfo,omitempty"`
 }
 
 type manifestApp struct {

--- a/core/apps_test.go
+++ b/core/apps_test.go
@@ -146,7 +146,7 @@ func TestAppDeleteError(t *testing.T) {
 	AssertErrorContains(t, ctx, `Error deleting app olaf from catalog: 403 Forbidden`)
 }
 
-const testManifest = `---
+const testManifestPrefix = `---
 applications:
 - name: olaf
   memory: 512M
@@ -166,7 +166,9 @@ applications:
       userName: "${user.userName}"
       firstName: "${user.firstName}"
       lastName: "${user.lastName}"
-    accessPolicy: %s
+    accessPolicy: %s`
+
+const testManifest = testManifestPrefix + `
     authInfo:
       type: Saml20
       validityTimeSeconds: 200
@@ -384,86 +386,34 @@ func TestPublishAppBadManifest(t *testing.T) {
 	AssertErrorContains(t, ctx, `Error getting manifest: open manifest.yaml: no such file or directory`)
 }
 
-func TestPublishAppInvalidAuthInfo(t *testing.T) {
-	testManifestInvalidAuthInfo := `---
-applications:
-- name: olaf
-  memory: 512M
-  instances: 1
-  path: build/libs/web-application-1.0.0.BUILD-SNAPSHOT.war
-  buildpack: https://github.com/cloudfoundry/java-buildpack/archive/master.zip
-  workspace:
-    packageVersion: '1.0'
-    description: Fanny's Demo App for RADIO
-    iconFile: %s
-    entitleGroup: ALL USERS
-    catalogItemType: Saml20
-    jsonTester: %s
-    attributeMaps:
-      userName: "${user.userName}"
-      firstName: "${user.firstName}"
-      lastName: "${user.lastName}"
-    accessPolicy: %s
+func TestPublishAppValidYAMLAuthInfo(t *testing.T) {
+	testManifestValidYAMLAuthInfo := testManifestPrefix + `
     authInfo:
       type: Saml20
       attributes:
       - name:
-        - not_supported:
+        - any_valid_yaml_is_supported:
           - test
 `
-	ctx := PublishAppTesterForManifest(t, appPubEnv{}, testManifestInvalidAuthInfo)
-	AssertErrorContains(t, ctx, `Error converting app olaf to JSON`)
+	ctx := PublishAppTesterForManifest(t, appPubEnv{}, testManifestValidYAMLAuthInfo)
+	AssertOnlyInfoContains(t, ctx, `App "olaf" added to the catalog`)
+	AssertOnlyInfoContains(t, ctx, `Entitled group "ALL USERS" to app "olaf"`)
 }
 
-func TestPublishAppInvalidAuthInfoMapOfMap(t *testing.T) {
-	testManifestInvalidAuthInfo := `---
-applications:
-- name: olaf
-  memory: 512M
-  instances: 1
-  path: build/libs/web-application-1.0.0.BUILD-SNAPSHOT.war
-  buildpack: https://github.com/cloudfoundry/java-buildpack/archive/master.zip
-  workspace:
-    packageVersion: '1.0'
-    description: Fanny's Demo App for RADIO
-    iconFile: %s
-    entitleGroup: ALL USERS
-    catalogItemType: Saml20
-    jsonTester: %s
-    attributeMaps:
-      userName: "${user.userName}"
-      firstName: "${user.firstName}"
-      lastName: "${user.lastName}"
-    accessPolicy: %s
+func TestPublishAppValidYAMLAuthInfoMapOfMap(t *testing.T) {
+	testManifestValidYAMLAuthInfo := testManifestPrefix + `
     authInfo:
       type: Saml20
       attributes:
         key: value
 `
-	ctx := PublishAppTesterForManifest(t, appPubEnv{}, testManifestInvalidAuthInfo)
-	AssertErrorContains(t, ctx, `Error converting app olaf to JSON`)
+	ctx := PublishAppTesterForManifest(t, appPubEnv{}, testManifestValidYAMLAuthInfo)
+	AssertOnlyInfoContains(t, ctx, `App "olaf" added to the catalog`)
+	AssertOnlyInfoContains(t, ctx, `Entitled group "ALL USERS" to app "olaf"`)
 }
 
-func TestPublishAppInvalidAuthInfoArrayOfArray(t *testing.T) {
-	testManifestInvalidAuthInfo := `---
-applications:
-- name: olaf
-  memory: 512M
-  instances: 1
-  path: build/libs/web-application-1.0.0.BUILD-SNAPSHOT.war
-  buildpack: https://github.com/cloudfoundry/java-buildpack/archive/master.zip
-  workspace:
-    packageVersion: '1.0'
-    description: Fanny's Demo App for RADIO
-    iconFile: %s
-    entitleGroup: ALL USERS
-    catalogItemType: Saml20
-    jsonTester: %s
-    attributeMaps:
-      userName: "${user.userName}"
-      firstName: "${user.firstName}"
-      lastName: "${user.lastName}"
-    accessPolicy: %s
+func TestPublishAppValidYAMLAuthInfoArrayOfArray(t *testing.T) {
+	testManifestValidYAMLAuthInfo := testManifestPrefix + `
     authInfo:
       type: Saml20
       attributes:
@@ -471,6 +421,7 @@ applications:
           -
             - key: value
 `
-	ctx := PublishAppTesterForManifest(t, appPubEnv{}, testManifestInvalidAuthInfo)
-	AssertErrorContains(t, ctx, `Error converting app olaf to JSON`)
+	ctx := PublishAppTesterForManifest(t, appPubEnv{}, testManifestValidYAMLAuthInfo)
+	AssertOnlyInfoContains(t, ctx, `App "olaf" added to the catalog`)
+	AssertOnlyInfoContains(t, ctx, `Entitled group "ALL USERS" to app "olaf"`)
 }

--- a/util/config.go
+++ b/util/config.go
@@ -53,6 +53,35 @@ func GetYamlFile(filename string, output interface{}) error {
 	}
 }
 
+/* YAML allows keys in maps to be datatypes other than string, whereas JSON only supports
+   keys that are strings. The YAML parser defaults to keys of type interface{}. This
+   function will take an object produced by the YAML parser and converts any map keys to
+   strings so that the object can be rendered as JSON.
+*/
+func ChangeKeysToString(input interface{}) interface{} {
+	switch inp := input.(type) {
+	case []interface{}:
+		output := make([]interface{}, len(inp))
+		for i, v := range inp {
+			output[i] = ChangeKeysToString(v)
+		}
+		return output
+	case map[interface{}]interface{}:
+		output := make(map[string]interface{})
+		for k, v := range inp {
+			output[fmt.Sprintf("%v", k)] = ChangeKeysToString(v)
+		}
+		return output
+	case map[string]interface{}:
+		output := make(map[string]interface{})
+		for k, v := range inp {
+			output[k] = ChangeKeysToString(v)
+		}
+		return output
+	}
+	return input
+}
+
 func PutYamlFile(filename string, input interface{}) error {
 	if f, err := yaml.Marshal(input); err != nil {
 		return err


### PR DESCRIPTION
Rather than have a custom JSON marshaller, this change fixes up
output from the YAML parser to be valid JSON (map keys are strings).
This allows any valid YAML to be included in the authInfo field.

Testing Done: make