### PR TITLE
Update cli.go

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+Copyright (c) 2016, 2018 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -35,12 +35,14 @@ const (
 	accessTokenTypeOption = "accesstokentype"
 	refreshTokenOption    = "refreshtoken"
 	idTokenOption         = "idtoken"
-	cliClientID           = "github.com-vmware-priam"
 	cliClientSecret       = "not-a-secret"
 	defaultAwsCredFile    = ".aws/credentials"
 	defaultAwsProfile     = "priam"
 	defaultAwsStsEndpoint = "https://sts.amazonaws.com"
 )
+
+// Initially a const, but now allowed to be a user-changeable value
+var cliClientID = "github.com-vmware-priam"
 
 var cliClientRegistration = map[string]interface{}{"clientId": cliClientID, "secret": cliClientSecret,
 	"accessTokenTTL": 60 * 60, "authGrantTypes": "authorization_code refresh_token", "displayUserGrant": false,
@@ -220,6 +222,14 @@ func cmdWithAuth0Arg(cfg *Config, cmd func(*HttpContext)) func(c *cli.Context) e
 		}
 		return nil
 	}
+}
+
+// User has requested a custom identity provider client id (login or token commands).  So
+// need to update the data structures that was using the default value.
+func updateClientID(clientID string) {
+	cliClientRegistration["clientId"] = clientID
+	strings.Replace(registerDescription, cliClientID, clientID, 1)
+	cliClientID = clientID
 }
 
 func Priam(args []string, defaultCfgFile string, infoW, errorW io.Writer) {
@@ -433,9 +443,13 @@ func Priam(args []string, defaultCfgFile string, infoW, errorW io.Writer) {
 			Flags: []cli.Flag{
 				cli.BoolFlag{Name: "authcode, a", Usage: "use browser to authenticate via oauth2 authorization code grant"},
 				cli.BoolFlag{Name: "client, c", Usage: "authenticate with oauth2 client ID and secret"},
+				cli.StringFlag{Name: "identifier, i", Usage: "Override client identifier, default is " + cliClientID},
 			},
 			Action: func(c *cli.Context) (err error) {
 				if a, ctx := initCmd(cfg, c, 0, 2, false, nil); ctx != nil {
+					if c.String("identifier") != "" {
+						updateClientID(c.String("identifier"))
+					}
 					tokenInfo := TokenInfo{}
 					tokenService := tokenServiceFactory.GetTokenService(cfg, cliClientID, cliClientSecret)
 					if c.Bool("authcode") {
@@ -606,9 +620,13 @@ func Priam(args []string, defaultCfgFile string, infoW, errorW io.Writer) {
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "credfile, c", Usage: "name of file to store AWS credentials. Default is ~/" + defaultAwsCredFile},
 						cli.StringFlag{Name: "profile, p", Usage: "Profile in which to store AWS credentials, Default is \"priam'\"."},
+						cli.StringFlag{Name: "identifier, i", Usage: "Override client identifier, default is " + cliClientID},
 					},
 					Action: func(c *cli.Context) error {
 						if args, ctx := initCmd(cfg, c, 1, 1, false, nil); ctx != nil {
+							if c.String("identifier") != "" {
+								updateClientID(c.String("identifier"))
+							}
 							tokenService := tokenServiceFactory.GetTokenService(cfg, cliClientID, cliClientSecret)
 							tokenService.UpdateAWSCredentials(ctx.Log, cfg.Option(idTokenOption),
 								args[0], defaultAwsStsEndpoint,


### PR DESCRIPTION
Added --identifier command line option to the priam login and priam token aws commands so that an alternate client identifier could be used.  This allows us to specify different access applications for different roles (e.g. readonly, admin or devops) so users can request command line access but only be granted access if they have been entitled to do so.